### PR TITLE
fix: 修复在oss下设置页面头像链接返回错误问题

### DIFF
--- a/Hooks.php
+++ b/Hooks.php
@@ -11,11 +11,29 @@ class Hooks {
 			'href' => \SpecialPage::getTitleFor("UploadAvatar")->getLinkURL(),
 		]);
 
+		global $wgAvatarEnableS3;
+		global $wgDefaultAvatar;
+		$ImgWhItExists =  OSSdispose::CheckFileExist($user->getId());
+		$imgLink = null;
+
+		if ($wgAvatarEnableS3) {
+	        if ($ImgWhItExists['code'] !== 1) {
+				$imgLink = $ImgWhItExists['code'] !== 2 ? Avatars::getLinkFor($user->getName()) : $wgDefaultAvatar;
+			}
+			else {
+				$imgLink = $wgDefaultAvatar;
+				printf("Error: %s", $ImgWhItExists['msg']);
+			}
+		}
+		else {
+			$imgLink = Avatars::getLinkFor($user->getName());
+		}
+
 		$preferences['editavatar'] = array(
 			'type' => 'info',
 			'raw' => true,
 			'label-message' => 'prefs-editavatar',
-			'default' => '<img src="' . Avatars::getLinkFor($user->getName()) . '" width="32" style="vertical-align: middle; margin-right: 8px;"></img> ' . $link,
+			'default' => '<img src="' . $imgLink . '" width="32" style="vertical-align: middle; margin-right: 8px;"></img> ' . $link,
 			'section' => 'personal/info',
 		);
 

--- a/includes/OSSDispose.php
+++ b/includes/OSSDispose.php
@@ -217,7 +217,7 @@ class OSSdispose {
      * @param mixed $FileName
      * @return array{code: int, msg: string}
      */
-    public static function CheckFileExist($userID, $FileName) {
+    public static function CheckFileExist($userID, $FileName='original') {
         $config =  MediaWikiServices::getInstance()->getMainConfig();
         $AvatarConfig = $config -> get('AvatarS3Config');
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 偏好设置中的头像图片将根据全局配置和存储位置动态选择，支持 S3 存储和默认头像展示。

- **修复**
  - 修正了头像文件名参数的默认值，提升了头像加载的兼容性和稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->